### PR TITLE
fix: handle None type for source file attributes in EnvSpec

### DIFF
--- a/snakemake_interface_software_deployment_plugins/tests.py
+++ b/snakemake_interface_software_deployment_plugins/tests.py
@@ -136,7 +136,8 @@ class TestSoftwareDeploymentBase(ABC):
         spec = deepcopy(self.get_env_spec())
         for attr in spec.source_path_attributes():
             source_file = getattr(spec, attr)
-            source_file.cached = source_file.path_or_uri
+            if source_file is not None:
+                source_file.cached = source_file.path_or_uri
         return spec
 
     def _get_env(self, tmp_path) -> EnvBase:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Fixed a rare crash when no source file is provided for an environment specification. The system now safely skips caching in this case, preventing intermittent errors and improving reliability during environment discovery and deployment. Behavior remains unchanged for projects with a source file, increasing robustness and reducing unexpected failures in runs without source metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->