### PR TITLE
fix: properly check source file type in test suite

### DIFF
--- a/snakemake_interface_software_deployment_plugins/tests.py
+++ b/snakemake_interface_software_deployment_plugins/tests.py
@@ -129,10 +129,15 @@ class TestSoftwareDeploymentBase(ABC):
 
     def test_source_path_attributes(self):
         spec = self.get_env_spec()
+
+        def is_source_file_or_none(attr: str) -> bool:
+            val = getattr(spec, attr)
+            return val is None or isinstance(val, EnvSpecSourceFile)
+
         assert all(
             isinstance(attr, str)
             and hasattr(spec, attr)
-            and isinstance(getattr(spec, attr), (EnvSpecSourceFile, None))
+            and is_source_file_or_none(attr)
             for attr in spec.source_path_attributes()
         ), "bug in plugin: all source path attributes must be of type EnvSpecSourceFile"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved robustness of tests for source path attributes by introducing a helper that correctly handles optional values, preventing type errors when attributes are None.
  * Enhances test reliability and clarity without impacting application behavior or public interfaces.
  * No production code changes; users will not see functional differences. Builds and releases are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->