### PR TITLE
fix: load concrete Env/EnvSpec classes instead of abstract bases

### DIFF
--- a/snakemake_interface_software_deployment_plugins/registry/__init__.py
+++ b/snakemake_interface_software_deployment_plugins/registry/__init__.py
@@ -37,8 +37,8 @@ class SoftwareDeploymentPluginRegistry(PluginRegistryBase):
             _name=name,
             common_settings=module.common_settings,
             _software_deployment_settings_cls=getattr(module, "Settings", None),
-            _env_cls=module.EnvBase,
-            _env_spec_cls=module.EnvSpecBase,
+            _env_cls=module.Env,
+            _env_spec_cls=module.EnvSpec,
         )
 
     def expected_attributes(self) -> Mapping[str, AttributeType]:


### PR DESCRIPTION
## Problem

`SoftwareDeploymentPluginRegistry.load_plugin()` populated the `Plugin` with:

```python
_env_cls=module.EnvBase,
_env_spec_cls=module.EnvSpecBase,
```

Each plugin module imports `EnvBase`/`EnvSpecBase` as the *abstract* base classes for its own `Env`/`EnvSpec` subclasses, so `module.EnvBase` / `module.EnvSpecBase` resolve to those abstract bases — not the concrete classes the plugin defines. As a result `plugin.env_spec_cls` was always `EnvSpecBase` (and `_env_cls` always `EnvBase`) for every plugin.

This is inconsistent with `expected_attributes()`, which already correctly requires the concrete `Env` and `EnvSpec` attributes.

## Impact

Because `plugin.env_spec_cls` was the abstract `EnvSpecBase`, methods like `source_path_attributes()` (abstract body `...`) returned `None`. Snakemake's software-deployment directive factory iterates `plugin.env_spec_cls.source_path_attributes()` and crashed:

```
TypeError: 'NoneType' object is not iterable
```

This broke every `software: <kind>(...)` directive at parse time (conda/container/envmodules), so the whole generic software-deployment feature was unusable with the published plugin versions.

## Fix

Read the concrete classes that plugins actually expose:

```python
_env_cls=module.Env,
_env_spec_cls=module.EnvSpec,
```

## Verification

With this change plus the corresponding snakemake-side fixes, the `software: conda(envfile=...)` path works end-to-end (the conda env is created and the rule runs); before this, any `software:` directive crashed in the factory. `plugin.env_spec_cls` now resolves to the concrete class for all plugins, e.g.:

```
conda:      env_spec_cls=EnvSpec, source_path_attributes=['envfile', 'pinfile']
container:  env_spec_cls=EnvSpec, source_path_attributes=[]
envmodules: env_spec_cls=EnvSpec
```

Context: snakemake/snakemake#4209.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin loading so deployment plugins now use the correct environment classes during initialization.
  * This helps ensure plugins are recognized and configured properly without changing their public interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->